### PR TITLE
Fixes for CMake Dependencies

### DIFF
--- a/src/Components/cda/clouds/CMakeLists.txt
+++ b/src/Components/cda/clouds/CMakeLists.txt
@@ -37,13 +37,14 @@ esma_add_f2py_module (ICA_
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib 
   ${include_${this}} ${esma_include}/MAPL.base
   )
-add_dependencies(ICA_ MAPL.base)
+add_dependencies(ICA_ MAPL.base ${this})
 
 esma_add_f2py_module (mcsRegrid_
   SOURCES mcsRegrid_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
+add_dependencies(mcsRegrid_ ${this})
 
 # these are executable scripts
 set (PYSCRIPTS

--- a/src/Components/misc/orbits/CMakeLists.txt
+++ b/src/Components/misc/orbits/CMakeLists.txt
@@ -19,6 +19,7 @@ esma_add_f2py_module (sgp4_
     INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib
     ${include_${this}}
     )
+add_dependencies(sgp4_ ${this})
 
 # these are executable scripts
 set (PYSCRIPTS


### PR DESCRIPTION
This adds a dependency on `${this}` for some f2py builds. These were needed for me to get `make -j8 install` to work for me. 