### PR TITLE
Update components to be in line with ADAS v5.29.0

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -1,23 +1,27 @@
+AeroApps:
+  fixture: true
+  develop: main
+
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v2.1.6
-  develop: master
+  tag: v3.2.1
+  develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.1.3
+  tag: v3.4.2
   develop: develop
 
 ecbuild:
   local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.0.5
+  tag: geos/v1.0.6
 
 MAPL:
   local: ./src/Shared/GMAO_Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.2.7
+  tag: v2.6.7
   develop: develop
 

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.4.2
+  tag: v3.4.4
   develop: develop
 
 ecbuild:

--- a/src/Components/cda/clouds/CMakeLists.txt
+++ b/src/Components/cda/clouds/CMakeLists.txt
@@ -22,26 +22,29 @@ esma_add_library (${this}
   )
 
 
+find_package(F2PY2 REQUIRED)
 
-esma_add_f2py_module (Aero_
+esma_add_f2py2_module (Aero_
   SOURCES Aero_py.F90
+  LIBRARIES MAPL.shared MAPL.base
   DESTINATION lib/Python/${this}
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib 
-  ${include_${this}} ${esma_include}/MAPL.shared ${esma_include}/MAPL.base
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/MAPL.shared ${esma_include}/MAPL.base
   )
 add_dependencies(Aero_ MAPL.shared MAPL.base)
 
-esma_add_f2py_module (ICA_
+# MAT: Using add_f2py2 as I haven't figured out how to add MKL to python import test (needs vscdfnorm_)
+add_f2py2_module (ICA_
   SOURCES ICA_py.F90
   DESTINATION lib/Python/${this}
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib 
-  ${include_${this}} ${esma_include}/MAPL.base
+  LIBRARIES ${this} MAPL.base
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/MAPL.base
   )
 add_dependencies(ICA_ MAPL.base ${this})
 
-esma_add_f2py_module (mcsRegrid_
+esma_add_f2py2_module (mcsRegrid_
   SOURCES mcsRegrid_py.F90
   DESTINATION lib/Python/${this}
+  LIBRARIES ${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
 add_dependencies(mcsRegrid_ ${this})

--- a/src/Components/misc/dee/CMakeLists.txt
+++ b/src/Components/misc/dee/CMakeLists.txt
@@ -1,6 +1,7 @@
 esma_set_this()
 
-add_f2py_module (duem_
+find_package(F2PY2 REQUIRED)
+esma_add_f2py2_module (duem_
   SOURCES duem_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}

--- a/src/Components/misc/obs_aod/ABC/CMakeLists.txt
+++ b/src/Components/misc/obs_aod/ABC/CMakeLists.txt
@@ -1,11 +1,11 @@
 esma_set_this ()
 
-
-esma_add_f2py_module (VLIDORT_BRDF_ABC_
+find_package(F2PY2 REQUIRED)
+esma_add_f2py2_module (VLIDORT_BRDF_ABC_
   SOURCES VLIDORT_BRDF_ABC_py.F90
   DESTINATION lib/Python/${this}
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib 
-  ${include_${this}} ${esma_include}/VLIDORT90)
+  LIBRARIES VLIDORT90
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/VLIDORT90)
 add_dependencies(VLIDORT_BRDF_ABC_ VLIDORT90)
 
 # these are non-executaables

--- a/src/Components/misc/orbits/CMakeLists.txt
+++ b/src/Components/misc/orbits/CMakeLists.txt
@@ -13,11 +13,12 @@ ecbuild_add_executable(
     LIBS ${this}
     )
 
-esma_add_f2py_module (sgp4_
+find_package(F2PY2 REQUIRED)
+esma_add_f2py2_module (sgp4_
     SOURCES sgp4_py.F90
     DESTINATION lib/Python/${this}
-    INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib
-    ${include_${this}}
+    LIBRARIES ${this}
+    INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
     )
 add_dependencies(sgp4_ ${this})
 

--- a/src/Components/misc/scat/CMakeLists.txt
+++ b/src/Components/misc/scat/CMakeLists.txt
@@ -1,43 +1,48 @@
 esma_set_this ()
 
-foreach (base Mie_ scat_MieObs_)
+find_package(F2PY2 REQUIRED)
 
-  esma_add_f2py_module (${base}
-    SOURCES ${base}py.F90
-    DESTINATION lib/Python/${this}
-    LIBRARIES Chem_Base
-    INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib
-    ${include_${this}} ${esma_include}/Chem_Base
-    )
-  add_dependencies(${base} Chem_Base)
-endforeach()
+# MAT: Note uses add_f2py2 because I can't figure out the import test for netCDF f2py code
+add_f2py2_module (Mie_
+  SOURCES Mie_py.F90
+  DESTINATION lib/Python/${this}
+  LIBRARIES Chem_Base GMAO_gfio_r4 ${NETCDF_LIBRARIES}
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/Chem_Base ${BASEDIR}/lib ${INC_NETCDF}
+  )
+add_dependencies(Mie_ Chem_Base GMAO_gfio_r4)
 
-esma_add_f2py_module (OMI_
+# MAT: Note uses add_f2py2 because I can't figure out the import test for netCDF f2py code
+add_f2py2_module (scat_MieObs_
+  SOURCES scat_MieObs_py.F90
+  DESTINATION lib/Python/${this}
+  LIBRARIES Chem_Base GMAO_mpeu ${NETCDF_LIBRARIES}
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/Chem_Base ${BASEDIR}/lib ${INC_NETCDF}
+  )
+add_dependencies(scat_MieObs_ Chem_Base GMAO_mpeu)
+
+esma_add_f2py2_module (OMI_
   SOURCES OMI_py.F90
   DESTINATION lib/Python/${this}
   LIBRARIES Chem_Base VLIDORT
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib
-  ${include_${this}} ${esma_include}/Chem_Base ${esma_include}/VLIDORT
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/Chem_Base ${esma_include}/VLIDORT
   )
 add_dependencies(OMI_ Chem_Base VLIDORT)
 
-esma_add_f2py_module (VLIDORT_BRDF_
+esma_add_f2py2_module (VLIDORT_BRDF_
   SOURCES VLIDORT_BRDF_py.F90
   DESTINATION lib/Python/${this}
   LIBRARIES VLIDORT90
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib 
-  ${include_${this}} ${esma_include}/VLIDORT90)
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}} ${esma_include}/VLIDORT90)
 add_dependencies(VLIDORT_BRDF_ VLIDORT90)
 
-esma_add_f2py_module (VLIDORT_OMI_
+esma_add_f2py2_module (VLIDORT_OMI_
   SOURCES VLIDORT_OMI_py.F90
   DESTINATION lib/Python/${this}
   LIBRARIES VLIDORT90
-  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib
-  ${include_${this}}  ${esma_include}/VLIDORT90)
+  INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}  ${esma_include}/VLIDORT90)
 add_dependencies(VLIDORT_OMI_ VLIDORT90)
 
-esma_add_f2py_module (VLIDORT_cloud_
+esma_add_f2py2_module (VLIDORT_cloud_
   SOURCES VLIDORT_cloud_py.F90
   DESTINATION lib/Python/${this}
   LIBRARIES Chem_Base VLIDORT90
@@ -45,7 +50,8 @@ esma_add_f2py_module (VLIDORT_cloud_
   )
 add_dependencies(VLIDORT_cloud_ Chem_Base VLIDORT90)
 
-esma_add_f2py_module (qsat_
+# Using add_f2py2_module here as I can't get the built-in import test to work
+esma_add_f2py2_module (qsat_
   SOURCES qsat_py.F90
   DESTINATION lib/Python/${this}
   LIBRARIES MAPL.base
@@ -53,7 +59,7 @@ esma_add_f2py_module (qsat_
   )
 add_dependencies(qsat_ MAPL.base)
 
-esma_add_f2py_module (scat_binObs_
+esma_add_f2py2_module (scat_binObs_
   SOURCES scat_binObs_py.F
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}

--- a/src/Components/qfed/CMakeLists.txt
+++ b/src/Components/qfed/CMakeLists.txt
@@ -7,31 +7,33 @@ esma_add_library (${this}
   DEPENDENCIES GMAO_mpeu GMAO_hermes GMAO_pyobs # crtm?
   )
 
-esma_add_f2py_module (ut_
+find_package(F2PY2 REQUIRED)
+
+esma_add_f2py2_module (ut_
   SOURCES ut_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
 
-esma_add_f2py_module (PlumeRise_
+esma_add_f2py2_module (PlumeRise_
   SOURCES qfed/PlumeRise_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
 
-esma_add_f2py_module (LockPlume_
+esma_add_f2py2_module (LockPlume_
   SOURCES qfed/LockPlume_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
 
-esma_add_f2py_module (tausfc_
+esma_add_f2py2_module (tausfc_
   SOURCES qfed/tausfc_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
   )
 
-esma_add_f2py_module (crtmmodis_
+esma_add_f2py2_module (crtmmodis_
   SOURCES qfed/crtmmodis_py.F90
   DESTINATION lib/Python/${this}
   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}

--- a/src/Shared/GMAO_Shared/Chem_Base/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/Chem_Base/CMakeLists.txt
@@ -17,7 +17,7 @@ target_compile_definitions (${this} PRIVATE GEOS5)
 
 ecbuild_add_executable(TARGET gogo.x SOURCES gogo.F90 LIBS ${this})
 
-# This MiObs_py.F90  is nearly identical to the one in ./src/Componenst/misc/scat.
+# This MieObs_py.F90  is nearly identical to the one in ./src/Componenst/misc/scat.
 #include (UseF2Py)
 #include_directories (${esma_include}/${this})
 #esma_add_f2py_module(MieObs_ SOURCES MieObs_py.F90 

--- a/src/Shared/GMAO_Shared/GMAO_gfio/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/GMAO_gfio/CMakeLists.txt
@@ -48,22 +48,21 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories (${BASEDIR}/lib)
 include_directories (${include_${this}})
 include_directories (${INC_NETCDF})
-include (UseF2Py)
-
-#esma_add_f2py_module(GFIO_ GFIO_py.F90
-#	DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 if (precision STREQUAL "r4")
-  esma_add_f2py_module(GFIO_ SOURCES GFIO_py.F90
-    DESTINATION lib/Python
-    ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
-    gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
-    gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
-    LIBRARIES GMAO_gfio_r4 ${NETCDF_LIBRARIES}
-    INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
-    USE_MPI
-    )
-  add_dependencies(GFIO_ ${this})
+  find_package(F2PY2)
+  if (F2PY2_FOUND)
+    esma_add_f2py2_module(GFIO_ SOURCES GFIO_py.F90
+      DESTINATION lib/Python
+      ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
+      gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
+      gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
+      LIBRARIES GMAO_gfio_r4 ${NETCDF_LIBRARIES}
+      INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
+      USE_MPI
+      )
+    add_dependencies(GFIO_ ${this})
+  endif ()
 endif ()
 
 ecbuild_add_executable(TARGET GFIO_mean_${precision}.x SOURCES GFIO_mean.f90 LIBS GMAO_gfio_${precision} )

--- a/src/Shared/GMAO_Shared/GMAO_ods/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/GMAO_ods/CMakeLists.txt
@@ -90,15 +90,17 @@ install (
    DESTINATION lib/Python/pyods
    )
 
-include(UseF2Py)
-esma_add_f2py_module(pyods_
-   SOURCES pyods_.F90
-   LIBRARIES GMAO_ods GMAO_mpeu ${NETCDF_LIBRARIES}
-   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
-   DESTINATION lib/Python/pyods
-   USE_MPI
-   )
-add_dependencies(pyods_ ${this})
+find_package(F2PY2)
+if (F2PY2_FOUND)
+  esma_add_f2py2_module(pyods_
+    SOURCES pyods_.F90
+    LIBRARIES GMAO_ods GMAO_mpeu ${NETCDF_LIBRARIES}
+    INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}
+    DESTINATION lib/Python/pyods
+    USE_MPI
+    )
+  add_dependencies(pyods_ ${this})
+endif ()
 
 separate_arguments(ODSMETA_ARGS NATIVE_COMMAND "sed -e 's/integer, parameter//g' -e 's/:://g' -e 's/\!/   #/g' -e 's/^[ ]*//g'")
 add_custom_command (

--- a/src/Shared/GMAO_Shared/GMAO_pyobs/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/GMAO_pyobs/CMakeLists.txt
@@ -10,18 +10,17 @@ esma_add_library (${this}
   DEPENDENCIES GMAO_gfio_r4
   INCLUDES ${INC_ESMF})
 
-include(UseF2Py)
-
+find_package(F2PY2 REQUIRED)
 # Duplicate target in ~/Components/misc/scat
 
-#esma_add_f2py_module(binObs_
+#esma_add_f2py2_module(binObs_
 #   SOURCES binObs_py.F
 #   DESTINATION lib/Python/pyobs
 #   INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${include_${this}}
 #   )
 #add_dependencies(binObs_ ${this})
 
-esma_add_f2py_module(IGBP_
+esma_add_f2py2_module(IGBP_
    SOURCES IGBP_py.F90
    DESTINATION lib/Python/pyobs
    ONLY getsimpleveg getdetailedveg


### PR DESCRIPTION
This PR brings AeroApps to be up-to-date with [GEOSadas v5.29.0.1](https://github.com/GEOS-ESM/GEOSadas/blob/v5.29.0.1/components.yaml). (NOTE: Slightly ahead as I needed to make changes to ESMA_cmake due to all the Python)

Note that since this advances ESMA_cmake, there are changed needed for calling F2PY code.

Before one did something like:
```cmake
   add_f2py_module(GFIO_ SOURCES GFIO_py.F90
      DESTINATION lib/Python
      ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
      gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
      gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
      )
   add_dependencies(GFIO_ ${this})
```
Now you need to do:
```cmake
   find_package(F2PY2)
    if (F2PY2_FOUND)
         esma_add_f2py2_module(GFIO_ SOURCES GFIO_py.F90
            DESTINATION lib/Python2
            ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
            gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime
            gfiointerpxy gfiointerpnn gfiocoordnn gfioclose
            )
         add_dependencies(GFIO_ ${this})
    endif ()
```
This was needed in order to support using Python 2 and 3 at the same time.

BUUUUUUUUUUUUUT the issue is that `esma_add_f2py2_module` tries to do a `python -c 'import mod_'` test. Unfortunately, some f2py modules are so complex I can't figure out how to do. If it needs netCDF or MKL I just gave up for now.