### PR TITLE
Fixes for f2py on GMAO desktops and calculon

### DIFF
--- a/src/Shared/GMAO_Shared/GMAO_gfio/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/GMAO_gfio/CMakeLists.txt
@@ -52,7 +52,8 @@ include_directories (${INC_NETCDF})
 if (precision STREQUAL "r4")
   find_package(F2PY2)
   if (F2PY2_FOUND)
-    esma_add_f2py2_module(GFIO_ SOURCES GFIO_py.F90
+    # Using add_ here as the import test threw an SSL error on GMAO desktop
+    add_f2py2_module(GFIO_ SOURCES GFIO_py.F90
       DESTINATION lib/Python
       ONLY gfioopen gfiocreate gfiodiminquire gfioinquire
       gfiogetvar gfiogetvart gfioputvar gfiogetbegdatetime

--- a/src/Shared/GMAO_Shared/GMAO_ods/CMakeLists.txt
+++ b/src/Shared/GMAO_Shared/GMAO_ods/CMakeLists.txt
@@ -92,7 +92,8 @@ install (
 
 find_package(F2PY2)
 if (F2PY2_FOUND)
-  esma_add_f2py2_module(pyods_
+  # Using add_ here as the import test threw an SSL error on GMAO desktop
+  add_f2py2_module(pyods_
     SOURCES pyods_.F90
     LIBRARIES GMAO_ods GMAO_mpeu ${NETCDF_LIBRARIES}
     INCLUDEDIRS ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/lib ${BASEDIR}/lib ${include_${this}} ${INC_NETCDF}


### PR DESCRIPTION
Testing on GMAO desktops and calculon found two more f2py calls that needed to be the simpler `add_` rather than `esma_add`. SSL again. My enemy, SSL...