### PR TITLE
Update to ESMA_cmake v3.4.5

### DIFF
--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.4.4
+  tag: v3.4.5
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This makes the f2py build "noisy" (see https://github.com/GEOS-ESM/ESMA_cmake/pull/197) if you build with Debug build type. Should aid in developing f2py