### PR TITLE
Update CMake in aeroapps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,16 +18,23 @@ if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
   # Set the possible values of build type for cmake-gui
   set_property (CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
-    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+    "Debug" "Release" "Aggressive") 
 endif ()
-
-set (DOING_GEOS5 YES)
 
 # Should find a better place for this - used in Chem component
 set (ACG_FLAGS -v)
-set (FV_PRECISION R4R8)
 
-list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake@")
+# mepo can now clone subrepos in three styles
+set (ESMA_CMAKE_DIRS
+  cmake
+  @cmake
+  cmake@
+  )
+foreach (dir IN LISTS ESMA_CMAKE_DIRS)
+  if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/${dir})
+    list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/${dir}")
+  endif ()
+endforeach ()
 include (esma)
 
 ecbuild_declare_project()
@@ -42,3 +49,17 @@ include_directories(${MPI_Fortran_INCLUDE_PATH})
 esma_add_subdirectory (env)
 esma_add_subdirectory (src)
 
+# https://www.scivision.dev/cmake-auto-gitignore-build-dir/
+# --- auto-ignore build directory
+if(NOT EXISTS ${PROJECT_BINARY_DIR}/.gitignore)
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
+endif()
+
+# Piggyback that file into install
+install(
+   FILES ${PROJECT_BINARY_DIR}/.gitignore
+   DESTINATION ${CMAKE_INSTALL_PREFIX}
+   )
+
+# Adds ability to tar source
+include(esma_cpack)

--- a/components.yaml
+++ b/components.yaml
@@ -11,7 +11,7 @@ env:
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.4.5
+  tag: v3.4.6
   develop: develop
 
 ecbuild:


### PR DESCRIPTION
This PR does a few things:

1. Updates ESMA_cmake to v3.4.6 which brings in the ability to do `make dist` to make a tarball of the source tree from a build directory
2. Cleans up the allowed `CMAKE_BUILD_TYPE` to the ones ESMA_cmake actually supports
3. Allows for the ability for users to use prefix, postfix, or naked mepo styles
4. Remove some unused CMake variables: `FV_PRECISION` and `DOING_GEOS5`
5. Automatically gitignore all build and install directories.