### PR TITLE
Update to ESMA_env v4.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,8 @@
 
 ### Changed
 
-- Update GMAOpyobs to v1.0.4
-- Update GMAOpyobs to v1.0.5
-- Update GMAOpyobs to v1.0.6
 - Update GMAOpyobs to v1.0.8
+- Update to ESMA_env v4.8.2 (fixes for RHEL8 GMAO machines)
 
 ## [v2.0.2] - 2023-05-25
 

--- a/components.yaml
+++ b/components.yaml
@@ -5,7 +5,7 @@ AeroApps:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.8.0
+  tag: v4.8.2
   develop: main
 
 cmake:


### PR DESCRIPTION
As found by @patricia-nasa, when calculon moved to RHEL8, Baselibs stopped working (as it was compiled for an older OS). This PR updates AeroApps to use [ESMA_env v4.8.2](https://github.com/GEOS-ESM/ESMA_env/releases/tag/v4.8.2) which has updates to allow RHEL8 GMAO compilation.