### PR TITLE
Try to fix odsqc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - bug in NNR cloud contamination check. Was not setting suspected too cloudy pixels to MISSING.
+- Fix missing MPI initialization
 
 ### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_policy (SET CMP0054 NEW)
 
 project (
   AeroApps
-  VERSION 2.0.1
+  VERSION 2.0.2
   LANGUAGES Fortran CXX C)  # Note - CXX is required for ESMF
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/src/Applications/GAAS_App/ana_aod.F
+++ b/src/Applications/GAAS_App/ana_aod.F
@@ -30,6 +30,7 @@
       use  m_simul
 
 
+      use m_mpif90, only : mp_init
       use  m_die
       use  m_zeit   ! timer
       use  m_FileResolv
@@ -114,8 +115,11 @@
 
 
       logical:: test_nan
-      integer k,l
+      integer k,l,ier
 
+
+      Call mp_init(ier)
+      if ( ier /= 0) call mp_die ( myname, 'MP_INIT()',ier)
 
       call zeit_ci ( 'ana_aod' )
 

--- a/src/Applications/GAAS_App/odsqc.F90
+++ b/src/Applications/GAAS_App/odsqc.F90
@@ -13,6 +13,7 @@
 !
 ! !USES:
 !
+      use  m_mpif90, only : mp_init
       use  m_odsmeta
       use  m_ods
       use  m_sqc
@@ -56,6 +57,9 @@
 !     storage for ODS:
 !     ---------------
       type (ods_vect) :: ods
+
+      Call mp_init(ier)
+      if ( ier /= 0) call mp_die ( myname, 'MP_INIT()',ier)
 
       call zeit_ci ( 'odsqc' )
 

--- a/src/Applications/GAAS_App/odsqc.F90
+++ b/src/Applications/GAAS_App/odsqc.F90
@@ -92,11 +92,11 @@
 
          do isyn = 1, 4
 
-           print *, 'Working on ... ', trim(infile(ifile)), nymd, nhms
-
 !          6-hourly files
 !          --------------
            nhms = (isyn-1) * 060000
+
+           print *, 'Working on ... ', trim(infile(ifile)), nymd, nhms
 
 !         Read all data for this synoptic time
 !         ------------------------------------

--- a/src/Shared/GMAO_Shared/GMAO_psas/m_GetAI.F90
+++ b/src/Shared/GMAO_Shared/GMAO_psas/m_GetAI.F90
@@ -389,7 +389,7 @@ Contains
 
     mpirun = ' '
     call getenv('MPIRUN',mpirun)             ! Unix binding
-    if(mpirun.eq.' ') Call die(myname_,'env var MPIRUN not set', 99)
+    !if(mpirun.eq.' ') Call die(myname_,'env var MPIRUN not set', 99)
 
 !   Invoke 'solve.x'
 !   ----------------

--- a/src/Shared/GMAO_Shared/GMAO_psas/m_RegionIterator.F90
+++ b/src/Shared/GMAO_Shared/GMAO_psas/m_RegionIterator.F90
@@ -66,7 +66,15 @@ Module m_RegionIterator
   Integer, Parameter :: coef(base_refinement:max_refinement) = &
        & (/ 1, 5, 21, 85, 341, 1365, 5461, 21845, 87381 /)
 
-  Integer :: err ! used for error conditions
+  integer :: err ! used for error conditions
+
+  interface new
+     module procedure new_
+  end interface new
+
+  interface clean
+     module procedure clean_
+  end interface clean
 
 ! !REVISION HISTORY:
 !        1Dec00 - Tom CLune and Peter Lyster <lys@dao.gsfc.nasa.gov>
@@ -120,7 +128,7 @@ Contains
 
   End Function RefinementToRegionIndex
 
-  Subroutine new(iter, level)
+  subroutine new_(iter, level)
     Implicit None
     Type (RegionIterator), Intent(Out) :: iter
     Integer, Intent(In) :: level
@@ -136,9 +144,9 @@ Contains
     iter%refinement_path(base_refinement) = 0
     iter%index = DONE
 
-  End Subroutine new
+  end subroutine new_
 
-  Subroutine clean(iter)
+  Subroutine clean_(iter)
     Type (RegionIterator), Intent(InOut) :: iter
 
     ALWAYS_ASSERT_NOMSG(Associated(iter%refinement_path))
@@ -147,7 +155,7 @@ Contains
     ASSERT(err == 0)
     Nullify(iter%refinement_path)
 
-  End Subroutine clean
+  End Subroutine clean_
 
   Integer Function reset(iter, level, index)
     Implicit None

--- a/src/Shared/GMAO_Shared/GMAO_psas/m_Spherical_Partition.F90
+++ b/src/Shared/GMAO_Shared/GMAO_psas/m_Spherical_Partition.F90
@@ -59,6 +59,7 @@ Module m_Spherical_Partition
 
     interface new   ; module procedure new_   ; end interface
     interface delete; module procedure delete_; end interface
+    interface clean; module procedure clean_; end interface
 
 #ifndef F95
   ! f95 allows default components in derived types and poiner initialization.
@@ -264,14 +265,14 @@ Contains
 !       NASA/GSFC, Data Assimilation Office, Code 910.3, GEOS/DAS      !
 !BOP -------------------------------------------------------------------
 !
-! !IROUTINE: clean - clean a partition
+! !IROUTINE: clean_ - clean a partition
 !
 ! !DESCRIPTION:
 !    This subroutine cleans up what initialize creates
 !
 ! !INTERFACE:
 
-  Subroutine clean(partition)
+  Subroutine clean_(partition)
     Use m_mall, only: mall_co, mall_ison
     Type (Spherical_Partition), Intent(InOut), Target, Optional :: partition
 ! !REVISION HISTORY:
@@ -287,7 +288,7 @@ Contains
         ALWAYS_ASSERT(err == 0)
     p_%refinement_level = INVALID
 
-  End Subroutine clean
+  End Subroutine clean_
 
 !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !       NASA/GSFC, Data Assimilation Office, Code 910.3, GEOS/DAS      !

--- a/src/Shared/GMAO_Shared/GMAO_psas/m_psas.F90
+++ b/src/Shared/GMAO_Shared/GMAO_psas/m_psas.F90
@@ -49,7 +49,7 @@
 ! !INTERFACE:
 !
       subroutine psas_init(I_AM_ROOT, comm, topology)
-	Use m_mpif90, only : MP_COMM_WORLD, MP_INIT, MP_COMM_RANK
+	Use m_mpif90, only : MP_COMM_WORLD, MP_INIT, MP_COMM_RANK, MP_initialized
         Use m_die, only : die, mp_die
 	Integer, Optional, Intent(Out) :: I_AM_ROOT
         Integer, Optional, Intent(Out) :: comm
@@ -71,12 +71,16 @@
         Integer :: rank
         Integer :: ier
         Integer :: topology_
+        Logical :: init_mpi
 
 
 !     Initialize MPI - must be done first
 !     -----------------------------------
-      Call MP_INIT(ier)
-         if ( ier /= 0) call mp_die ( myname_, 'MP_INIT()',ier)
+      call MP_initialized (init_mpi,ier)
+      if (.not.init_mpi) then
+         Call MP_INIT(ier)
+            if ( ier /= 0) call mp_die ( myname_, 'MP_INIT()',ier)
+      endif
       Call MP_COMM_RANK(MP_COMM_WORLD, rank, ier)
          if ( ier /= 0) call mp_die ( myname_, 'MP_COMM_RANK()',ier)	
       If (Present(comm)) comm = MP_COMM_WORLD


### PR DESCRIPTION
Both @patricia-nasa and @seungheelee811 have had issues running `odsqc.x` on calculon and discover respectively. They get the error:

```
Attempting to use an MPI routine before initializing MPICH
```

Usually this message (which both I and @bena-nasa have seen before) means you are trying to run MPI code without running `MPI_Init`. 

This PR tries to bring over code from the latest GMAO_Shared and GAAS_App to see if it can fix it. My memory is that this was encountered long ago in the GEOSadas and these were the fixes.