### PR TITLE
Feature/sgassoumd/mpl dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+Extract TROPOMI pixels over MPL sites
 ### Fixed
 
 ### Changed

--- a/src/Components/AOCH/MPL/collocate_tropo_mpl.py
+++ b/src/Components/AOCH/MPL/collocate_tropo_mpl.py
@@ -24,7 +24,8 @@ is an arbitrary label defined by user.
 4) Code requires the module f_collocate_2 to be located in the same directory
 5) Customize this code at will 
 
-
+Apr/9/2025 - updated script get_orbit_site_matches to deal with missing folder or missing files 
+Apr/8/2025 - added loop over years
 
 @author: sgasso@umd.edu
 """
@@ -37,95 +38,99 @@ from datetime import datetime, timedelta
 
 ### Load specific modules. 
 #from pyobs.tropomi_l2_reader import TROPOAER_L2 # need to read TROPOMI data
-import f_collocate_2  as fc #needed for finding pixels that contain site 
+import WIP_f_collocate  as fc #needed for finding pixels that contain site 
 
 if __name__ == "__main__":
     # 
     
     #### User Input , Most of the codes can operate with yyyy and Julian day
     #### But I haven''t tested. I do need to change how julian1 and julian2 are set.
-
-    verb = 0
-    #yyyy0,mm0,dd0=[2023,1,1]; yyyy1,mm1,dd1=[2023,12,31]
-    yyyy0,mm0,dd0=[2023,8,1]; yyyy1,mm1,dd1=[2023,8,10]
-    user_string = "TEST" # additional string to add to output file SiteName_yyyy_<user_string>.txt
-    #julian=359 
-
-    #### End user input section 
-    #--------------------------------------------------
-    if not yyyy0 : sys.exit('Input year most be provided')
-    # if not mm and not julian : sys.exit('Either Month and day or Julian day must be provided')
-
-    current_working_directory = os.getcwd()
-    current_os    = platform.system()
-    computer_name = platform.node()
-    if verb<1 :
-        print('\nThis code is running from directory :', current_working_directory)
-        print(f'This code is executed in computer {computer_name} \n')
-    
-    #### # Convert to datetime objects
-    start_date = datetime(yyyy0, mm0, dd0)
-    end_date   = datetime(yyyy1, mm1, dd1)
-    # Initialize the combined dictionary to store all results
-    combined_results = {}
-    
-    # Loop through each day
-    current_date = start_date
-    start_time = datetime.now() # start timing the loop
-    while current_date <= end_date:
-        start_time_day = datetime.now()
-        # Extract year, month, day into separate variables
-        yyyy = current_date.year
-        mm   = current_date.month
-        dd   = current_date.day
-        # if only julian day is provided, then compute mm and dd to get selected day
-        if not mm:
-            date = datetime(yyyy, 1, 1) + timedelta(days=julian - 1)
-            mm = date.month
-            dd = date.day
-        SEL_DATE = datetime(yyyy,mm,dd)
-        if verb>1: print(f"Current date: {yyyy}-{mm:02d}-{dd:02d}")
+    for iyear in [2019,2020,2021,2022,2023,2024]:
+    #for iyear in [2020]:    
+        verb = 0
+        #yyyy0,mm0,dd0=[2020,12,5]; yyyy1,mm1,dd1=[2020,12,6]
+        yyyy0,mm0,dd0=[iyear,1,1]; yyyy1,mm1,dd1=[iyear,12,31]
+        user_string = "complete" # additional string to add to output file SiteName_yyyy_<user_string>.txt
         
-        #### Get user defined text file with MPL sites
-        pth_site_list  = current_working_directory + '/' + 'list_mpl_sites_2.txt'
-        mpl_sites_list = fc.read_mpl_site_list(pth_site_list)
-        SEL_DATE = datetime(yyyy,mm,dd) # 
+        output_path='/nobackup/2/MPL/Collocations/'  # location of collocation files
+        #julian=359 
 
-         
-        #### Now get list of files and the path to corresponding folder
-        matching_orbits_list,current_pth =\
-                fc.get_orbit_site_matches(mpl_sites_list,yyyy, mm, dd,verb)
+        #### End user input section 
+        #--------------------------------------------------
+        if not yyyy0 : sys.exit('Input year most be provided')
+        # if not mm and not julian : sys.exit('Either Month and day or Julian day must be provided')
 
-        ##### Now find the line and column number of pixels w/MPL sites inside in selected TROPomi orbits
-        output_array = fc.process_matching_orbits(matching_orbits_list, 
-                                             current_pth, SEL_DATE,mpl_sites_list,verb)
-        #print("")
-        # Update combined_results with new data
-        for key, value in output_array.items():
-            if key in combined_results:
-                # Extend existing list with new values
-                combined_results[key].extend(value)
-            else:
-                # Create new key-value pair
-                combined_results[key] = value.copy()        
-        print(f"       This day time: {(datetime.now() - start_time_day).total_seconds():.2f} seconds")
+        current_working_directory = os.getcwd()
+        current_os    = platform.system()
+        computer_name = platform.node()
+        if verb<1 :
+            print('\nThis code is running from directory :', current_working_directory)
+            print(f'This code is executed in computer {computer_name} \n')
+        
+        #### # Convert to datetime objects
+        start_date = datetime(yyyy0, mm0, dd0)
+        end_date   = datetime(yyyy1, mm1, dd1)
+        # Initialize the combined dictionary to store all results
+        combined_results = {}
+        
+        # Loop through each day
+        current_date = start_date
+        start_time = datetime.now() # start timing the loop
+        while current_date <= end_date:
+            start_time_day = datetime.now()
+            # Extract year, month, day into separate variables
+            yyyy = current_date.year
+            mm   = current_date.month
+            dd   = current_date.day
+            # if only julian day is provided, then compute mm and dd to get selected day
+            if not mm:
+                date = datetime(yyyy, 1, 1) + timedelta(days=julian - 1)
+                mm = date.month
+                dd = date.day
+            SEL_DATE = datetime(yyyy,mm,dd)
+            if verb>1: print(f"Current date: {yyyy}-{mm:02d}-{dd:02d}")
+            
+            #### Get user defined text file with MPL sites
+            pth_site_list  = current_working_directory + '/' + 'list_mpl_sites.txt'
+            mpl_sites_list = fc.read_mpl_site_list(pth_site_list)
+            SEL_DATE = datetime(yyyy,mm,dd) # 
 
-        #### next value for iteration
-        current_date += timedelta(days=1)
-    
-    #### Done with loop over each day
-    end_time = datetime.now()
-    time_diff = (end_time - start_time).total_seconds()
-    print(f"\nLoop Execution time: {time_diff:.2f} seconds")
-    
-    
-    ### Save one file per site
-    ### Inputs: array_to_save, year_string,user_string
-    fc.create_output_files(combined_results, "2023", user_string)
-    
-    if verb >-1 :
-        print('\nThis code is running from directory :', current_working_directory)
-        print(f'This code is executed in computer {computer_name} \n')
+             
+            #### Now get list of files and the path to corresponding folder
+            matching_orbits_list,current_pth =\
+                    fc.get_orbit_site_matches(mpl_sites_list,yyyy, mm, dd,verb)
 
-    print("\nDone!")
+            ##### Now find the line and column number of pixels w/MPL sites inside in selected TROPomi orbits
+            output_array = fc.process_matching_orbits(matching_orbits_list, 
+                                                 current_pth, SEL_DATE,mpl_sites_list,verb)
+            #print("")
+            # Update combined_results with new data
+            for key, value in output_array.items():
+                if key in combined_results:
+                    # Extend existing list with new values
+                    combined_results[key].extend(value)
+                else:
+                    # Create new key-value pair
+                    combined_results[key] = value.copy()        
+            print(f"       This day time: {(datetime.now() - start_time_day).total_seconds():.2f} seconds")
+
+            #### next value for iteration
+            current_date += timedelta(days=1)
+        
+        #### Done with loop over each day
+        end_time = datetime.now()
+        time_diff = (end_time - start_time).total_seconds()
+        print(f"\nLoop Execution time: {time_diff:.2f} seconds")
+        
+        
+        ### Save one file per site
+        ### Inputs: array_to_save, year_string,user_string
+        fc.create_output_files(output_path,combined_results, str(yyyy0), user_string)
+        
+        if verb >-1 :
+            print('\nThis code is running from directory :', current_working_directory)
+            print(f'This code is executed in computer {computer_name} \n')
+            print('Files are saved in directory ', output_path)
+
+        print("\nDone!")
 

--- a/src/Components/AOCH/MPL/f_collocate.py
+++ b/src/Components/AOCH/MPL/f_collocate.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Mar/3/2025 . Set of subroutines called by collocate_tropo_mpl_2.py . Code requires the module pyobs.tropomi_l2_reader
+Apr/8/2025 Added an output path for output files
 
+Mar/3/2025 . Set of subroutines called by collocate_tropo_mpl_2.py . Code requires the module pyobs.tropomi_l2_reader
 
 @author: sgasso
 """
@@ -13,7 +14,8 @@ import numpy as np
 from pathlib import Path
 from datetime import datetime, timedelta
 
-from pyobs.tropomi_l2_reader import TROPOAER_L2 # need to read TROPOMI data
+from src.pyobs.tropoaer import TROPOAER_L2 # need to read TROPOMI data
+#from tropoaer import TROPOAER_L2 # need to read TROPOMI data
 
 
 #------------ Functions related to reach the files 
@@ -68,18 +70,61 @@ def read_mpl_site_list(filename):
     return sites
 
 
-def get_orbit_site_matches(list_mpl_sites,yyyy, mm=None, dd=None, julian=None, verb=0):
-#--------------------------------------------------------------------------------------------
-#     Inputs:
-#     list_mpl_sites : 
-#     yyyy : int , Year
-#     mm : int, optional ,  Month (1-12)
-#     dd : int, optional ,  Day (1-31)
-#     julian : int, optional , Julian day (alternative to mm/dd)
-#     verb : int, optional ,  Verbose output flag (default: 0,0: minimal print ,1: some print 2: print all)
-#         
-#     Returns: List containing files with files in selected directory and the path to the folder
-#--------------------------------------------------------------------------------------------
+# def get_orbit_site_matches(list_mpl_sites,yyyy, mm=None, dd=None, julian=None, verb=0):
+# #--------------------------------------------------------------------------------------------
+# #     Inputs:
+# #     list_mpl_sites : 
+# #     yyyy : int , Year
+# #     mm : int, optional ,  Month (1-12)
+# #     dd : int, optional ,  Day (1-31)
+# #     julian : int, optional , Julian day (alternative to mm/dd)
+# #     verb : int, optional ,  Verbose output flag (default: 0,0: minimal print ,1: some print 2: print all)
+# #         
+# #     Returns: List containing files with files in selected directory and the path to the folder
+# #--------------------------------------------------------------------------------------------
+    
+    # if not yyyy:
+        # raise ValueError('Input year must be provided')
+    # if not mm and not julian:
+        # raise ValueError('Either Month and day or Julian day must be provided')
+
+    # # Set correct paths according to the current computer and OS
+    # current_working_directory = os.getcwd()
+    # current_os           = platform.system()
+    # computer_name        = platform.node()
+    # current_pth, pth_fig = get_path(current_os.lower(), computer_name)
+    
+    # # Convert mm/dd to julian if needed
+    # if mm:
+        # date_obj = datetime(yyyy, mm, dd)
+        # julian = (date_obj - datetime(yyyy, 1, 1)).days + 1
+    # julian_str = f"{julian:03d}"
+
+    # if verb>-1:print(f'   Year is {yyyy}, julian {julian_str}, {date_obj:%Y-%m-%d}')
+
+    # # Get list of files for selected date
+    # path_2_folder_with_orbits = current_pth+str(yyyy)+'/'+julian_str +'/'
+    # file_list = glob.glob(path_2_folder_with_orbits+'*.nc')
+    
+    # # Process orbit information
+    # orbits_list = []
+    # for full_pathname in file_list:
+        # orbits_list.append(full_pathname[-80:])
+
+    # return orbits_list,path_2_folder_with_orbits
+
+def get_orbit_site_matches(list_mpl_sites, yyyy, mm=None, dd=None, julian=None, verb=0):
+    #--------------------------------------------------------------------------------------------
+    #     Inputs:
+    #     list_mpl_sites : 
+    #     yyyy   : int , Year
+    #     mm     : int, optional ,  Month (1-12)
+    #     dd     : int, optional ,  Day (1-31)
+    #     julian : int, optional , Julian day (alternative to mm/dd)
+    #     verb   : int, optional ,  Verbose output flag (default: 0,0: minimal print ,1: some print 2: print all)
+    #         
+    #     Returns: List containing files with files in selected directory and the path to the folder
+    #--------------------------------------------------------------------------------------------
     
     if not yyyy:
         raise ValueError('Input year must be provided')
@@ -102,15 +147,39 @@ def get_orbit_site_matches(list_mpl_sites,yyyy, mm=None, dd=None, julian=None, v
 
     # Get list of files for selected date
     path_2_folder_with_orbits = current_pth+str(yyyy)+'/'+julian_str +'/'
+    
+    # Check if folder exists
+    if not os.path.isdir(path_2_folder_with_orbits):
+        if verb>0:
+            print(f"Folder for julian day {julian_str} does not exist. Returning empty outputs.")
+        return [], path_2_folder_with_orbits  # Return empty list and the path (even though it doesn't exist)
+    
+    # Get list of files for selected date
     file_list = glob.glob(path_2_folder_with_orbits+'*.nc')
+    
+    # Filter files by size (non-zero size)
+    valid_files = []
+    for file_path in file_list:
+        try:
+            file_size = os.path.getsize(file_path)
+            if file_size > 0:  # Keep only non-zero size files
+                valid_files.append(file_path)
+            elif verb>1:
+                print(f"Skipping zero-size file: {os.path.basename(file_path)}")
+        except OSError:
+            if verb>1:
+                print(f"Error accessing file: {os.path.basename(file_path)}")
+    
+    # Update file_list with only valid files
+    file_list = valid_files
     
     # Process orbit information
     orbits_list = []
     for full_pathname in file_list:
         orbits_list.append(full_pathname[-80:])
 
-    return orbits_list,path_2_folder_with_orbits
-
+    return orbits_list, path_2_folder_with_orbits
+    
 #------------------------- 
 #---------- functions related to finding sites in each orbit
 #-------------------------
@@ -149,14 +218,15 @@ def find_nearest_point_haversine(lat_array, lon_array, lat0, lon0):
     dist0 = R * c  # Distance in kilometers
     return row, col,dist0
     
-def create_output_files(output_array, year, userstring):
+def create_output_files(output_path,output_array, year, userstring):
     header = 'yyyy-mm-dd hh:mm:ss.d,orbit_number,source_filename     ,line,column'
+    # get the key with the site name
     for key in output_array.keys():
         # Create filename using the specified format
         filename = f"{key}_{year}_{userstring}.txt"
         print('...... Saving to file ', filename)
         # Open file for writing
-        with open(filename, 'w') as f:
+        with open(output_path+filename, 'w') as f:
           # Write header first
             f.write(header + '\n')
             # Loop through each tuple in the array

--- a/src/Components/AOCH/MPL/list_mpl_sites.txt
+++ b/src/Components/AOCH/MPL/list_mpl_sites.txt
@@ -1,3 +1,18 @@
-Name_MPL_sites , name,lat, lon, altitude(km)
-GSFC                ,38.9930,-76.8400,0.050 
-Santa_Cruz_Tenerife ,28.4720,-16.2470,0.052 
+Name_MPL_sites               , lat, lon, altitude(km)
+Appalachian_State            , 36.2150, -81.6940,1.080
+Barcelona                    , 41.3860,   2.1170,0.125
+CARTEL                       , 45.3790, -71.9310,0.251
+El_Arenosillo                , 37.1050,  -6.7340,0.059
+EPA-NCU                      , 24.9670, 121.1810,0.135
+GSFC                         , 38.9930, -76.8400,0.050 
+Izana                        , 28.3090, -16.4990,2.401
+KAUST_Campus                 , 22.3050,  39.1030,0.011 
+London-CDN                   , 43.0080, -81.2700,0.258 
+Santa_Cruz_Tenerife          , 28.4720, -16.2470,0.052 
+Sao_Paolo                    ,-23.5620, -46.7350,0.865
+SEDE_BOKER                   , 30.8550,  34.7820,0.480
+Silpakorn_Univ               , 13.8190, 100.0410,0.072 
+Singapore                    ,  1.2980, 103.7800,0.030
+Songkhla_Regional_Observatory,  7.1580, 100.6100,0.105
+UH_Liberty                   , 30.0970, -94.7630,0.020
+Univ_of_Nevada-Reno          , 39.5410,-119.8140,1.410


### PR DESCRIPTION
A set of scripts to extract line and column number of each TROPOMI orbit overpass by a MPL site.

User must provide an external input file (see list_mpl_sites.txt), set date ranges, an output string and location of output folder.

Output filename (text files) : <site_name><user_set_string>.txt

See examples of outputs at /nobackup/2/MPL/Collocations/

Main code is collocate_tropo_mpl.py, which invoques the modules in script f_collocate.py .

It requires tropoaer.py reader in GMAOpyobs. 

This code must be ran in Calculon where the TROPOMI Level 2 files reside.