### PR TITLE
Update components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,187 @@ parallel_build.o*
 /src/Shared/GMAO_Shared/MAPL@/
 /src/Shared/GMAO_Shared/MAPL/
 /src/Shared/GMAO_Shared/@MAPL/
+
+*.log
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@
 ### Changed
 
 - Update `components.yaml`
-  - ESMA_env: Updated tag from v4.8.2 to v4.36.0
-  - ESMA_cmake: Updated tag from v3.28.0 to v3.59.0
+  - ESMA_env: Updated tag from v4.8.2 to v4.38.0
+  - ESMA_cmake: Updated tag from v3.28.0 to v3.62.1
   - ecbuild: Updated tag from geos/v1.3.0 to geos/v1.4.0
-  - MAPL: Updated tag from v2.39.0 to v2.55.0
+  - MAPL: Updated tag from v2.39.0 to v2.55.1
 - Modified `src/Shared/GMAO_Shared/GMAO_etc/argopt.c`:
   - Added include for `<unistd.h>` to access `getopt` function 
+- Updated `README.md` to modern CMake
+- Updated `.gitignore` to ignore more Python detritus
 
 ## [v2.1.0] - 2025-02-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - MAPL: Updated tag from v2.39.0 to v2.55.1
 - Modified `src/Shared/GMAO_Shared/GMAO_etc/argopt.c`:
   - Added include for `<unistd.h>` to access `getopt` function 
-- Updated `README.md` to modern CMake
+- Updated `README.md` and `cmake_it` to modern CMake
 - Updated `.gitignore` to ignore more Python detritus
 
 ## [v2.1.0] - 2025-02-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,20 @@
 ## [Unreleased]
 
 ### Added
-Extract TROPOMI pixels over MPL sites
+
+- Extract TROPOMI pixels over MPL sites
+
 ### Fixed
 
 ### Changed
+
+- Update `components.yaml`
+  - ESMA_env: Updated tag from v4.8.2 to v4.36.0
+  - ESMA_cmake: Updated tag from v3.28.0 to v3.59.0
+  - ecbuild: Updated tag from geos/v1.3.0 to geos/v1.4.0
+  - MAPL: Updated tag from v2.39.0 to v2.55.0
+- Modified `src/Shared/GMAO_Shared/GMAO_etc/argopt.c`:
+  - Added include for `<unistd.h>` to access `getopt` function 
 
 ## [v2.1.0] - 2025-02-14
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ module use -a /nobackup/gmao_SIteam/modulefiles
 ```
 
 ##### GMAO Desktops
+
 On the GMAO desktops, the SI Team modulefiles should automatically be
 part of running `module avail` but if not, they are in:
 
@@ -61,6 +62,7 @@ This is a one-time command that tells mepo to use blobless clones for all future
 #### Build the Model
 
 ##### Load Compiler, MPI Stack, and Baselibs
+
 On tcsh:
 ```
 source env@/g5_modules
@@ -71,35 +73,45 @@ source env@/g5_modules.sh
 ```
 
 ##### Create Build Directory
-We currently do not allow in-source builds of GEOSgcm. So we must make a directory:
-```
-mkdir build
-```
-The advantages of this is that you can build both a Debug and Release version with the same clone if desired.
 
 ##### Run CMake
+
 CMake generates the Makefiles needed to build the model.
+
+On bash you can run:
+
 ```
-cd build
-cmake .. -DBASEDIR=$BASEDIR/Linux -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build -S . --install-prefix=$(pwd)/install
 ```
-This will install to a directory parallel to your `build` directory. If you prefer to install elsewhere change the path in:
+
+and on tcsh:
+
 ```
--DCMAKE_INSTALL_PREFIX=<path>
+cmake -B build -S . --install-prefix=`pwd`/install
 ```
-and CMake will install there.
+
+This will build the code in `build/` and will install in `install`.
+
+NOTE: You can choose any directory for your build and install. That
+said, what you pass to `--install-prefix=` *MUST* be a full path.
 
 ###### Building with Debugging Flags
+
 To build with debugging flags add:
+
 ```
 -DCMAKE_BUILD_TYPE=Debug
 ```
 to the cmake line.
 
 ##### Build and Install with Make
+
 ```
-make -j6 install
+cmake --build build --target install -j 6
 ```
+
+If you put your build in a directory other than `build` use that in the
+above command.
 
 ## Contributing
 

--- a/cmake_it
+++ b/cmake_it
@@ -4,9 +4,4 @@
 #
 
 source env@/g5_modules # to be sure
-mkdir -p build
-cd build
-cmake .. -DBASEDIR=$BASEDIR/`uname -s` \
-         -DCMAKE_Fortran_COMPILER=ifort \
-         -DCMAKE_INSTALL_PREFIX=../install
-      
+cmake -B build -S . --install-prefix=`pwd`/install

--- a/components.yaml
+++ b/components.yaml
@@ -5,13 +5,13 @@ AeroApps:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.36.0
+  tag: v4.38.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.59.0
+  tag: v3.62.1
   develop: develop
 
 ecbuild:
@@ -22,7 +22,7 @@ ecbuild:
 MAPL:
   local: ./src/Shared/GMAO_Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.55.0
+  tag: v2.55.1
   develop: develop
 
 GMAOpyobs:

--- a/components.yaml
+++ b/components.yaml
@@ -5,24 +5,24 @@ AeroApps:
 env:
   local: ./env@
   remote: ../ESMA_env.git
-  tag: v4.8.2
+  tag: v4.36.0
   develop: main
 
 cmake:
   local: ./cmake@
   remote: ../ESMA_cmake.git
-  tag: v3.28.0
+  tag: v3.59.0
   develop: develop
 
 ecbuild:
   local: ./cmake@/ecbuild@
   remote: ../ecbuild.git
-  tag: geos/v1.3.0
+  tag: geos/v1.4.0
 
 MAPL:
   local: ./src/Shared/GMAO_Shared/MAPL@
   remote: ../MAPL.git
-  tag: v2.39.0
+  tag: v2.55.0
   develop: develop
 
 GMAOpyobs:

--- a/src/Shared/GMAO_Shared/GMAO_etc/argopt.c
+++ b/src/Shared/GMAO_Shared/GMAO_etc/argopt.c
@@ -67,6 +67,7 @@ Modification log:
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>    /* for getopt */
 
 int main(int argc, char *argv[]);
 


### PR DESCRIPTION
This PR updates the `components.yaml` for AeroApps. Indeed, it is about as updated as you can get (beating GEOSgcm `main`).

The main reason for this is odd Python/f2py behavior. This was first seen by @vbuchard (which has similar, if a bit older updates in her `feature/vbuchard/QC` branch). However, recently, Ravi also encountered something similar on calculon.

When I then tried this on calculon, I found *another* f2py/CMake issue and fixed that.

I also took the time to update the `README.md` and `cmake_it` script to modern CMake. I also updated the `.gitignore` to ignore more Python detritus as I almost committed a `.so` in my testing.

---

NOTE 1: This is most likely non-zero-diff as it does update the compiler to Intel 2021.13.

NOTE 2: I'm keeping this draft until @patricia-nasa and Ravi can test respectively. I mean, it should work